### PR TITLE
git-sync integration with deploycache

### DIFF
--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -99,4 +99,4 @@ unset JWT_MAX_TOKEN_AGE_IN_SECONDS
 # HTPASSWD Needs
 unset HTPASSWD
 # deploycache server to prevent us from spamming GitHub
-export GLG_DEPLOYCACHE_URL="https://deploycache-internal.glgresearch.com/deploycache/sha"
+unset GLG_DEPLOYCACHE_URL

--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -98,3 +98,5 @@ unset JWT_EXPIRATION_IN_SECONDS
 unset JWT_MAX_TOKEN_AGE_IN_SECONDS
 # HTPASSWD Needs
 unset HTPASSWD
+# deploycache server to prevent us from spamming GitHub
+export GLG_DEPLOYCACHE_URL="https://deploycache-internal.glgresearch.com/deploycache/sha"

--- a/overlay/etc/starphleet
+++ b/overlay/etc/starphleet
@@ -99,4 +99,4 @@ unset JWT_MAX_TOKEN_AGE_IN_SECONDS
 # HTPASSWD Needs
 unset HTPASSWD
 # deploycache server to prevent us from spamming GitHub
-unset GLG_DEPLOYCACHE_URL
+unset DEPLOYCACHE_URL

--- a/scripts/starphleet-git-synch
+++ b/scripts/starphleet-git-synch
@@ -48,9 +48,9 @@ if [ -d "${local}/.git" ]; then
     exit 0
   fi
 
-  if [[ -n "${GLG_DEPLOYCACHE_URL}" ]]; then
+  if [[ -n "${DEPLOYCACHE_URL}" ]]; then
     # Extract ORG/USER and REPO from $REMOTE
-    read -r GIT_ORG GIT_REPO <<< $(awk -F "[#/:]" '{gsub(/[.]git$/, "", $(NF)); print $(NF-1),$(NF)}' <<< "${REMOTE}")
+    read -r GIT_ORG GIT_REPO <<< $(awk -F "[/:]" '{gsub(/[.]git$/, "", $(NF)); print $(NF-1),$(NF)}' <<< "${REMOTE}")
 
     # deploycache route
     #
@@ -65,8 +65,9 @@ if [ -d "${local}/.git" ]; then
         --data-urlencode "owner=${GIT_ORG}" \
         --data-urlencode "repo=${GIT_REPO}" \
         --data-urlencode "name=${BRANCH}" \
-        "${GLG_DEPLOYCACHE_URL}" \
+        "${DEPLOYCACHE_URL}" \
         2> /dev/null \
+        | head -n 1 \
         | awk 'BEGIN{ RS = "" ; FS = "\n" }{printf "%s ", $NF; NF--; print}'
       )
 
@@ -75,11 +76,11 @@ if [ -d "${local}/.git" ]; then
       warn "deploycache status code: ${DEPLOYCACHE_STATUS_CODE}"
       exit 1
     else
-      # make sure that jq can process what was returned
-      LATEST_REMOTE_SHA="$(echo "\"${DEPLOYCACHE_RESPONSE}\"" | (jq -r "." 2> /dev/null || echo -n "null"))"
+      # make sure that the line contains a 40 character SHA, otherwise assign null
+      LATEST_REMOTE_SHA="$(echo -n "${DEPLOYCACHE_RESPONSE}" | awk '{if ($1 ~ /[a-fA-F0-9]{40}/) { print $1 } else { print "null" }}')"
     fi
     if [[ "${LATEST_REMOTE_SHA}" = "null" ]]; then
-      # parsing failure will result is no update
+      # parsing failure will result in no update
       warn "could not obtain LATEST_REMOTE_SHA"
       exit 1
     fi

--- a/scripts/starphleet-git-synch
+++ b/scripts/starphleet-git-synch
@@ -67,7 +67,6 @@ if [ -d "${local}/.git" ]; then
         --data-urlencode "name=${BRANCH}" \
         "${DEPLOYCACHE_URL}" \
         2> /dev/null \
-        | head -n 1 \
         | awk 'BEGIN{ RS = "" ; FS = "\n" }{printf "%s ", $NF; NF--; print}'
       )
 
@@ -77,7 +76,7 @@ if [ -d "${local}/.git" ]; then
       exit 1
     else
       # make sure that the line contains a 40 character SHA, otherwise assign null
-      LATEST_REMOTE_SHA="$(echo -n "${DEPLOYCACHE_RESPONSE}" | awk '{if ($1 ~ /[a-fA-F0-9]{40}/) { print $1 } else { print "null" }}')"
+      LATEST_REMOTE_SHA="$(echo -n "${DEPLOYCACHE_RESPONSE}" | head -n 1 | awk '{if ($1 ~ /[a-fA-F0-9]{40}/) { print $1 } else { print "null" }}')"
     fi
     if [[ "${LATEST_REMOTE_SHA}" = "null" ]]; then
       # parsing failure will result in no update

--- a/scripts/starphleet-git-synch
+++ b/scripts/starphleet-git-synch
@@ -17,6 +17,8 @@ local="${local:-$(basename ${REMOTE})}"
 STARTING_DIRECTORY=$(pwd)
 trap 'cd "${STARTING_DIRECTORY}"' EXIT
 
+# Info: exit 0 in this script means, that the repo has changed, or was updated
+
 reclone () {
   cd ..
   rm -rf "${local}"
@@ -32,18 +34,64 @@ if [ -d "${local}/.git" ]; then
   ORIGIN_URL=$(git config remote.origin.url)
   #make sure we have the correct repository and branch
   if [ "${ORIGIN_URL}" != "${REMOTE}" ]; then
+    # Info: Local HQ repo, diffrent from remote, so clone remote
     warn repository url differs, reclone needed
     reclone
     exit 0
-  else
-    starphleet-git fetch --all &> /dev/null || fatal fetch error
   fi
+
+  # Info: Local HQ repo correct, branch different from requested, reclone HQ with proper branch checked out
   CURRENT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
   if [ "${BRANCH}" != "${CURRENT_BRANCH}" ]; then
     warn specified branch changed, checking out ${BRANCH}
     reclone
     exit 0
   fi
+
+  if [[ -n "${GLG_DEPLOYCACHE_URL}" ]]; then
+    # Extract ORG/USER and REPO from $REMOTE
+    read -r GIT_ORG GIT_REPO <<< $(awk -F "[#/:]" '{gsub(/[.]git$/, "", $(NF)); print $(NF-1),$(NF)}' <<< "${REMOTE}")
+
+    # deploycache route
+    #
+    # explanation of awk: row separator no longer \n, field seperator is \n,
+    # print last field, followed by all other fields.
+    #   {"status": "error", "message": "Cannot read property 'headers' of undefined"}
+    #   500
+    # turns into:
+    #   500 {"status": "error", "message": "Cannot read property 'headers' of undefined"}
+    read -r DEPLOYCACHE_STATUS_CODE DEPLOYCACHE_RESPONSE <<< $(
+      curl --silent --show-error --get --write-out '\n%{http_code}' \
+        --data-urlencode "owner=${GIT_ORG}" \
+        --data-urlencode "repo=${GIT_REPO}" \
+        --data-urlencode "name=${BRANCH}" \
+        "${GLG_DEPLOYCACHE_URL}" \
+        2> /dev/null \
+        | awk 'BEGIN{ RS = "" ; FS = "\n" }{printf "%s ", $NF; NF--; print}'
+      )
+
+    if [[ "${DEPLOYCACHE_STATUS_CODE}" != "200" ]]; then
+      # if we don't get a successful response from deploycache we don't update
+      warn "deploycache status code: ${DEPLOYCACHE_STATUS_CODE}"
+      exit 1
+    else
+      # make sure that jq can process what was returned
+      LATEST_REMOTE_SHA="$(echo "\"${DEPLOYCACHE_RESPONSE}\"" | (jq -r "." 2> /dev/null || echo -n "null"))"
+    fi
+    if [[ "${LATEST_REMOTE_SHA}" = "null" ]]; then
+      # parsing failure will result is no update
+      warn "could not obtain LATEST_REMOTE_SHA"
+      exit 1
+    fi
+    LATEST_LOCAL_SHA="$(git rev-parse HEAD)"
+    if [[ "${LATEST_REMOTE_SHA}" = "${LATEST_LOCAL_SHA}" ]]; then
+      # if the sha is still the same as current, no update
+      exit 1
+    fi
+    warn "LATEST_REMOTE_SHA and LATEST_LOCAL_SHA are different ($LATEST_REMOTE_SHA, $LATEST_LOCAL_SHA)"
+  fi
+  starphleet-git fetch --all &> /dev/null || fatal fetch error
+
   CURRENT_BRANCH=$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)
   HAS_CHANGES=$(git diff HEAD...origin/${CURRENT_BRANCH} --raw)
   if [ "${HAS_CHANGES}x" != "x" ]; then


### PR DESCRIPTION
### Overview

- `/overlay/etc/starphleet` contains new `GLG_DEPLOYCACHE_URL` env var, which turns on feature if set.
- `/scripts/starphleet-git-sync` contains new logic to only fetch updates from github if the new glg/deploycache service shows a difference in SHA from what's currently in the local repos on starphleet.

> - The idea is, instead of performing a fetch against github to see if a new commit is available, we check a cached version of the SHA, per org+repo+branch.  If the cache shows a change, we execute the standard starphleet workflow.
> - Outside of the SHA difference detection, there are no workflow changes to starphleet

Related to https://github.com/glg/metadevops-issues/issues/213

### Sample stats from build server

> The line in bold/italic is what we are addressing which is causing GitHub to block us.

Stats: starting with 53337 events
* No Repo "not found, initial clone needed from"
  - clone 614
* Have Repo
  * Different Remote "repository url differs, reclone needed"
    - clone 1
  * Same Remote
    - __*fetch 52723*__ (FIXING THIS)
    * Different Branch "specified branch changed, checking out"
      - clone 3
    * Out of Date "new code detected, pulling"
      - fetch 122
      - reset
    * Not current "this clone is not current, reclone needed"
      - clone 0
    * Divergent "this clone is diverged, reclone needed"
      - clone 0

fatal error 0
no update 52598