### PR TITLE
Fix arp cache overflow

### DIFF
--- a/overlay/etc/sysctl.d/100-starphleet.conf
+++ b/overlay/etc/sysctl.d/100-starphleet.conf
@@ -3,3 +3,11 @@ net.netfilter.nf_conntrack_count = 131072
 net.netfilter.nf_conntrack_generic_timeout = 60
 net.netfilter.nf_conntrack_tcp_timeout_time_wait = 30
 net.netfilter.nf_conntrack_tcp_timeout_established = 86400
+# Force gc to clean-up quickly
+net.ipv4.neigh.default.gc_interval = 3600
+# Set ARP cache entry timeout
+net.ipv4.neigh.default.gc_stale_time = 3600
+# Setup DNS threshold for arp 
+net.ipv4.neigh.default.gc_thresh3 = 4096
+net.ipv4.neigh.default.gc_thresh2 = 2048
+net.ipv4.neigh.default.gc_thresh1 = 1024


### PR DESCRIPTION
- Error:

[354334.806221] net_ratelimit: 32 callbacks suppressed
[354334.806225] neighbour: arp_cache: neighbor table overflow!
[354335.231361] neighbour: arp_cache: neighbor table overflow!
[354335.402546] neighbour: arp_cache: neighbor table overflow!
[354335.516331] neighbour: arp_cache: neighbor table overflow!
[354335.516431] neighbour: arp_cache: neighbor table overflow!
[354335.523486] neighbour: arp_cache: neighbor table overflow!