### PR TITLE
improved error messages for fromJson

### DIFF
--- a/scripts/tools
+++ b/scripts/tools
@@ -383,13 +383,13 @@ json_string, json_key = sys.argv[1:]
 try:
     obj = json.loads(json_string)
 except Exception:
-    print >> sys.stderr, \"fromJson({}): Invalid JSON -- {}\".format(\"$0\", json_string)
+    print >> sys.stderr, \"fromJson({}): This isn't json!\".format(\"$0\")
     sys.exit(0)
 
 try:
     value = obj[json_key]
 except Exception:
-    print >> sys.stderr, \"fromJson({}): error reading key ({}) from json ({})\".format(\"$0\", json_key, json_string)
+    print >> sys.stderr, \"fromJson({}): error reading key ({}) from json\".format(\"$0\", json_key)
     sys.exit(0)
 
 print value" \

--- a/scripts/tools
+++ b/scripts/tools
@@ -381,9 +381,18 @@ function fromJson() {
 import sys
 json_string, json_key = sys.argv[1:]
 try:
-    print json.loads(json_string)[json_key]
+    obj = json.loads(json_string)
 except Exception:
-    print >> sys.stderr, \"This isn't json!\"" \
+    print >> sys.stderr, \"fromJson({}): Invalid JSON -- {}\".format(\"$0\", json_string)
+    sys.exit(0)
+
+try:
+    value = obj[json_key]
+except Exception:
+    print >> sys.stderr, \"fromJson({}): error reading key ({}) from json ({})\".format(\"$0\", json_key, json_string)
+    sys.exit(0)
+
+print value" \
     "${1}" "${2}"
 }
 


### PR DESCRIPTION
I made the errors from `fromJson` more informative:

```shell
➜  starphleet git:(fromJson-errors) bash meh.sh '{"json":"here","cat":"pants"}' test
fromJson(meh.sh): error reading key (test) from json

➜  starphleet git:(fromJson-errors) bash meh.sh '{"json":"here","cat":"pants"' test
fromJson(meh.sh): This isn't json!
```

The goal was for the file name to be the `orders` file, but I'm not really sure how it's called or if that is the first (0th) parameter even. It was an attempt at making the messages more meaningful.

FYI This is the contents of `meh.sh` which I assume sort of mimics the way `orders` are run, but I'm not a starphleet-ologist yet so ¯\\\_(ツ)\_/¯ :

```shell
source ~/.functions

from-json '{"json":"here","cat":"pants"}' $1
```