### PR TITLE
Log container build output

### DIFF
--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -84,12 +84,7 @@ else
   #
   #  See more here:  http://glg.link/vQpIdw
   #
-  if [[ "$(lxc-attach --version)" =~ ^1 ]]; then
-    LXC_OPT_FOR_STDOUT="-o /dev/stdout"
-  else
-    LXC_OPT_FOR_STDOUT="-L /dev/stdout"
-  fi
-
+  LXC_OPT_FOR_STDOUT="-L /dev/stdout"
 
   # If SERVE_CONTAINERS is _not_ set - we would always want to fall back to
   # default behavior (behavior before introducing container storage).  This

--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -171,11 +171,14 @@ EOF
     lxc-start --name ${CONTAINER_NAME} -d
     starphleet-lxc-wait ${CONTAINER_NAME} RUNNING
 
-    # start off by assuming we need -L
+    # start off by assuming we need -L in order to capture logs
+    # - mainly upstart, when not started from cloudinit
     LXC_OPT_FOR_STDOUT="-L /dev/stdout"
-    # if it doesn't work, stop using it
+    # if the context the scripts run in causes the -L option to fail, we remove the option
+    # - crontab
+    # - cloudinit
     lxc-attach --name ${CONTAINER_NAME} ${LXC_OPT_FOR_STDOUT} -- bash -c "true" 2> /dev/null || LXC_OPT_FOR_STDOUT=""
-    # if we happen to have a terminal, we don't need it
+    # if we are on a terminal, -L needs to be removed because it causes double outputs
     if [[ -t 0 ]] && [[ -t 1 ]] && [[ -t 2 ]]; then
       LXC_OPT_FOR_STDOUT=""
     fi

--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -72,20 +72,6 @@ else
   # load the ship name as configured in /etc/starphleet-name or, just use the sucky hostname
   SHIP_NAME=$([ -r /etc/starphleet-name ] && $(echo cat /etc/starphleet-name) || echo $(hostname))
 
-  # On LXC >= 1.0.10 - lxc-attach no longer attaches to STDOUT when run
-  # from upstart.  They changed how pty assignments are handled.
-  # From the new docs:
-  #
-  #     -L, --pty-log file
-  #        Specify a file where the output of lxc-attach will be logged.
-  #
-  #        Important: When a standard file descriptor does not refer to
-  #        a pty output produced on it will not be logged.
-  #
-  #  See more here:  http://glg.link/vQpIdw
-  #
-  LXC_OPT_FOR_STDOUT="-L /dev/stdout"
-
   # If SERVE_CONTAINERS is _not_ set - we would always want to fall back to
   # default behavior (behavior before introducing container storage).  This
   # probably represents a legacy machine or one not configured for container
@@ -184,6 +170,16 @@ EOF
     info "Starting the container"
     lxc-start --name ${CONTAINER_NAME} -d
     starphleet-lxc-wait ${CONTAINER_NAME} RUNNING
+
+    # start off by assuming we need -L
+    LXC_OPT_FOR_STDOUT="-L /dev/stdout"
+    # if it doesn't work, stop using it
+    lxc-attach --name ${CONTAINER_NAME} ${LXC_OPT_FOR_STDOUT} -- bash -c "true" 2> /dev/null || LXC_OPT_FOR_STDOUT=""
+    # if we happen to have a terminal, we don't need it
+    if [[ -t 0 ]] && [[ -t 1 ]] && [[ -t 2 ]]; then
+      LXC_OPT_FOR_STDOUT=""
+    fi
+
     lxc-attach --name ${CONTAINER_NAME} ${LXC_OPT_FOR_STDOUT} -- bash starphleet-wait-network
 
     #host file updates

--- a/scripts/starphleet-containermake
+++ b/scripts/starphleet-containermake
@@ -84,10 +84,10 @@ else
   #
   #  See more here:  http://glg.link/vQpIdw
   #
-  if [[ "$(lxc --version)" =~ ^1 ]]; then
-    LXC_OPT_FOR_STDOUT="-L /dev/stdout"
-  else
+  if [[ "$(lxc-attach --version)" =~ ^1 ]]; then
     LXC_OPT_FOR_STDOUT="-o /dev/stdout"
+  else
+    LXC_OPT_FOR_STDOUT="-L /dev/stdout"
   fi
 
 


### PR DESCRIPTION
https://app.zenhub.com/workspaces/infrastructure---sre-5d92320acdc7cf0001013e24/issues/glg/metadevops-issues/233

### Overview

There were changes to both upstart and lxc-attach, that caused us to lose the ability in certain scenarios to log the output of lxc-attach.

- lxc-attach running with -L option in cloud init, failed to to lack of tty.  running it w/o -L works
- lxc-attach running with -L option on terminal based scripts, causes double output, so -L should not be used
- lxc-attach running in upstart as a job or started by srd requires -L option in order to log.