### PR TITLE
not all jwt secured sites need to require auth every time

### DIFF
--- a/overlay/var/starphleet/nginx/lua/jwt.lua
+++ b/overlay/var/starphleet/nginx/lua/jwt.lua
@@ -235,10 +235,10 @@ end
 
 ------------------------------------------------------------------------------
 -- acr claim and auth required:
--- if auth requred and no token set the header.
+-- if auth required and no token set the header.
 -- If auth is required and the acr claim is missing set header.
 ------------------------------------------------------------------------------
-if jwt_auth_required then
+if jwt_auth_required == "true" then
   ngx.req.set_header('X-Starphleet-Auth-Required', jwt_auth_required)
   if token and token.payload and not token.payload.acr then
     token = nil


### PR DESCRIPTION
The publish script sets `jwt_auth_required` to the string-interpolated value of the environment variable `"${JWT_AUTH_REQUIRED}"`

So, when environment variable `JWT_AUTH_REQUIRED` does not exist, the nginx variable is set to an empty string.  In Lua, empty strings are truthy, so the check needs to be more explicit.