### PR TITLE
Add SameSite Attribute to JWT and Session Cookies

### DIFF
--- a/overlay/var/starphleet/nginx/lua/jwt.lua
+++ b/overlay/var/starphleet/nginx/lua/jwt.lua
@@ -442,6 +442,7 @@ if (token) then
       cookieString = cookieString .. (signedJwtToken and cookie_name .. "=" .. signedJwtToken or '')
       cookieString = cookieString .. (jwt_cookie_domain and '; Domain=' .. jwt_cookie_domain or '')
       cookieString = cookieString .. '; Path=/'
+      userCookieString = userCookieString .. '; SameSite=Lax'
       cookieString = cookieString .. (jwt_expiration_in_seconds and '; Expires=' .. ngx.cookie_time(token.payload.exp) or '')
       table.insert(_setCookie, cookieString)
     end
@@ -469,6 +470,7 @@ if (token) then
       cookieString = cookieString .. (signedJwtToken and cookie_name .. "=" .. signedJwtToken or '')
       cookieString = cookieString .. (jwt_cookie_domain and '; Domain=' .. jwt_cookie_domain or '')
       cookieString = cookieString .. '; Path=/'
+      userCookieString = userCookieString .. '; SameSite=Strict'
       cookieString = cookieString .. (jwt_expiration_in_seconds and '; Expires=' .. ngx.cookie_time(token.payload.exp) or '')
       table.insert(_setCookie, cookieString)
     end


### PR DESCRIPTION
Our [most recent penetration test indicated](https://github.com/glg/information-security/issues/307) most of our web apps are vulnerable to [cross-site request forgeries (CSRF's)](https://en.wikipedia.org/wiki/Cross-site_request_forgery), as they will accept requests from malicious third party domains, provided the proper authentication cookie (`jwt`)  is passed with the request.  On the client side, some browsers will readily pass along this authentication cookie with requests from malicious third party domains to our web apps.

This vulnerable behavior can be stopped by adding the `SameSite=Lax` or `SameSite=Strict` attribute to the `jwt` and `session` cookies in the starphleet JWT overlay. GLG is already operating under some variant of the SameSite regime, as Google has already begun the process of treating all cookies as `SameSite=Lax`.

My review of our source code and testing of our apps indicates this approach will work, and I am staging this pull request to serve as a reference point for discussion.