### PR TITLE
AWS CLI v2 resolves pulling containers from s3...

### DIFF
--- a/scripts/tools
+++ b/scripts/tools
@@ -326,13 +326,14 @@ function container_environment() {
 function get_updated_aws_command {
   AWS_INSTALL_LOCK_FILE="/var/lock/aws_command_install"
   # Because aws cli on our machines is a mixed bag and I really do
-  # want a modern version.  It's okay if they aren't consistent for
-  # what we are doing so long as the version isn't 10 years old.
+  # want anything above version 1.  It's okay if they aren't consistent for
+  # what we are doing so long as the version isn't 1.
   export AWS_COMMAND_PATH="/usr/local/bin/aws"
 
   # Test if we need to upgrade aws cli
   unset UPGRADE
-  if $AWS_COMMAND_PATH --version 2>&1 | grep 'aws-cli/1.11'; then
+  # any version of AWS CLI 1 will fail us
+  if $AWS_COMMAND_PATH --version 2>&1 | grep 'aws-cli/1'; then
     UPGRADE=true
   fi
 
@@ -342,23 +343,14 @@ function get_updated_aws_command {
     (
       flock -n 250
       set +e
-      # New pip install wanted libyaml so we'll install that before trying
-      # to get the latest AWS cli
-      apt-get update -y
-      apt-get install -y libyaml-dev python-dev python-docutils python-pip
+      # Need to be able to unzip the install
+      sudo apt-get update -y
+      sudo apt-get install -y unzip
       #######
-      ## Because:  https://github.com/aws/aws-cli/issues/2999#issuecomment-356019306
-      pip uninstall boto3 -y
-      pip uninstall boto -y
-      pip uninstall botocore -y
-      # Fix bug caused by apt/ubuntu
-      rm -rf /usr/local/lib/python2.7/dist-packages/botocore-*.dist-info
-      pip install botocore --force-reinstall --upgrade
+      sudo curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+      sudo unzip awscliv2.zip
+      sudo ./aws/install
       #######
-      ## Because: https://github.com/aws/aws-cli/issues/3007#issuecomment-350797161
-      pip install --upgrade s3transfer
-      rm -rf /tmp/pip_build_root/PyYAML
-      pip install awscli --force-reinstall --upgrade
       rm "${AWS_INSTALL_LOCK_FILE}"
       set -e
       # Let the caller test if things went okay


### PR DESCRIPTION
along with some other issues. We had updated the AWS CLI version within the base-container,
however the scripts that run commands to pull from S3 are still leveraging and attempting
to install AWS CLI v1. This should be the last place we are using the AWS CLI v1. This also
resolves thhe current issue of not being able to spin up new starphleet ships.

This is also related to the internet moving out from under us and not keeping our python/ubuntu/everything starphleet related up-to-date. 
- [This teams thead outlines the issues with the devships.](https://teams.microsoft.com/l/message/19:7fe878d4940f4dd29134a328ddb209c0@thread.skype/1617732485102?tenantId=ce6e7548-545e-40c2-b32d-a76b6acc9c2e&groupId=ee9ab99a-a595-4adc-946f-3231dc177b6e&parentMessageId=1617732485102&teamName=MetaDevOps&channelName=SRE&createdTime=1617732485102)
- [This was the previous PR that fixed the issue on devships from within the starphleet-base container.](https://github.com/glg/starphleet/commit/ccc6b50edfa4a701b51c836677874dd61f536d32)

### Testing
I've confirmed this in a trusty Ubuntu Docker image (`alias trusty='docker run -t -i --rm ubuntu:trusty bash'`, along with on the new services ship that came up to replace the deprecated ship.