### PR TITLE
Explicit region container storage

### DIFF
--- a/scripts/starphleet-s3-get-container
+++ b/scripts/starphleet-s3-get-container
@@ -9,7 +9,6 @@ run_as_root_or_die
 [ -z "${containerName}" ] && echo Please pass the name of a container && exit 1
 
 # These envs are required for the AWS command line
-export AWS_DEFAULT_REGION="${S3_STORAGE_BUCKET_REGION}"
 export AWS_ACCESS_KEY_ID="${S3_STORAGE_AWS_ACCESS_KEY_ID}"
 export AWS_SECRET_ACCESS_KEY="${S3_STORAGE_AWS_SECRET_ACCESS_KEY}"
 

--- a/scripts/starphleet-s3-get-container
+++ b/scripts/starphleet-s3-get-container
@@ -17,5 +17,8 @@ export AWS_SECRET_ACCESS_KEY="${S3_STORAGE_AWS_SECRET_ACCESS_KEY}"
 get_updated_aws_command
 
 S3_PATH_FOR_CONTAINER_STORAGE="s3://${S3_STORAGE_BUCKET_PATH}"
-"${AWS_COMMAND_PATH}" s3 cp "${S3_PATH_FOR_CONTAINER_STORAGE}/${containerName}.tar.gz" . \
+# Specify region here because orders files can unset variables...
+# I also want to be explicit, as any parameter in the CLI will override
+# any other profiles or environment variables.
+"${AWS_COMMAND_PATH}" s3 cp --region "${S3_STORAGE_BUCKET_REGION}" "${S3_PATH_FOR_CONTAINER_STORAGE}/${containerName}.tar.gz" . \
   || exit ${EXIT_CODE_FOR_FAILED_S3_DOWNLOADS}

--- a/scripts/starphleet-s3-put-container
+++ b/scripts/starphleet-s3-put-container
@@ -10,7 +10,6 @@ run_as_root_or_die
 get_updated_aws_command
 
 # These envs are required for the AWS command line
-export AWS_DEFAULT_REGION="${S3_STORAGE_BUCKET_REGION}"
 export AWS_ACCESS_KEY_ID="${S3_STORAGE_AWS_ACCESS_KEY_ID}"
 export AWS_SECRET_ACCESS_KEY="${S3_STORAGE_AWS_SECRET_ACCESS_KEY}"
 

--- a/scripts/starphleet-s3-put-container
+++ b/scripts/starphleet-s3-put-container
@@ -24,7 +24,10 @@ if is_container_storage_on_s3 \
   info "Pushing ${CONTAINER_NAME} to S3 Bucket Path ${S3_STORAGE_BUCKET_PATH}"
 
   export S3_PATH_FOR_CONTAINER_STORAGE="s3://${S3_STORAGE_BUCKET_PATH}"
-  "${AWS_COMMAND_PATH}" s3 cp "${CONTAINER_ROOT}/${CONTAINER_NAME}.tar.gz" "${S3_PATH_FOR_CONTAINER_STORAGE}/${CONTAINER_NAME}.tar.gz"
+  # Specify region here because orders files can unset variables...
+  # I also want to be explicit, as any parameter in the CLI will override
+  # any other profiles or environment variables.
+  "${AWS_COMMAND_PATH}" s3 cp --region "${S3_STORAGE_BUCKET_REGION}" "${CONTAINER_ROOT}/${CONTAINER_NAME}.tar.gz" "${S3_PATH_FOR_CONTAINER_STORAGE}/${CONTAINER_NAME}.tar.gz"
 fi
 
 # Because explicit..


### PR DESCRIPTION
While deploying a new services ship, I've come across an issue where the orders files of some services ([aws dev creds china](https://github.com/glg/ec2.starphleet.headquarters.lb/blob/b969cb93662cf0d7885992b98bfbaeed737a454a/aws-china-dev-creds/orders#L20) and [notify](https://github.com/glg/ec2.starphleet.headquarters.lb/blob/b969cb93662cf0d7885992b98bfbaeed737a454a/notify/orders#L5)) are unsetting our AWS_REGION via the [run_orders function](https://github.com/glg/starphleet/blob/eb181836d905c7067d5957ccb63efbfe5eccfcc9/scripts/tools#L184). You'd think in the case of notify, since the region is set in the secret, it would thus pull the value from secrets. However, in run_orders we stub out the secrets function, thus setting the AWS_REGION to `null`. Same situation in the case of aws-dev-creds-china...

This fix makes us explicitly use the region in the AWS CLI command, as that trumps any other environment or profile settings ([according to the docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html)). I noticed this issue while 'pulling' containers, but have preemptively patched the push as well. 